### PR TITLE
Allow level to be specified in config file

### DIFF
--- a/tasks/phpstan.js
+++ b/tasks/phpstan.js
@@ -10,12 +10,21 @@ module.exports = function (grunt) {
             const done = this.async();
             const options = this.options(
                 {
-                    level: 1,
+                    level: null,
                     bin: "phpstan",
                     config: null
                 }
             );
-            let args = ["analyze", "-l", options.level];
+            let args = ["analyze"];
+
+            // if no level has been specified and no config file has been specified, default the level to 1
+            if(options.level === null && options.config === null) {
+                options.level = 1;
+            }
+
+            if (options.level) {
+                args.push("-l", options.level);
+            }
             if (options.config) {
                 args.push("-c", options.config);
             }


### PR DESCRIPTION
Currently if level isn't provided in the grunt config it defaults to 1, this overrides any level that has been specified in the phpstan config file, so if you want to specify the level only in the config file it is not currently possible.

Change the task so the default of 1 is used only if the config file has not been provided, otherwise it's null. 
Conditionally include the level arguments rather than including it every time.